### PR TITLE
use Map.has_key? to check for keys assigns data

### DIFF
--- a/priv/templates/mandarin.gen.html/sidebar-link.html.eex
+++ b/priv/templates/mandarin.gen.html/sidebar-link.html.eex
@@ -7,7 +7,7 @@
     <ul class="treeview-menu">
       <li><%%= link(index_label, to: Routes.admin_<%= schema.singular %>_path(@conn, :index)) %></li>
       <li><%%= link(new_label, to: Routes.admin_<%= schema.singular %>_path(@conn, :new)) %></li>
-      <%%= if Map.get(assigns, :<%= schema.singular %>) && @<%= schema.singular %>.id do %>
+      <%%= if Map.has_key?(assigns, :<%= schema.singular %>) && Map.has_key?(@<%= schema.singular %>, :id) do %>
         <li><%%= link(edit_label, to: Routes.admin_<%= schema.singular %>_path(@conn, :edit, @<%= schema.singular %>.id)) %></li>
         <li><%%= link(delete_label, to: Routes.admin_<%= schema.singular %>_path(@conn, :delete, @<%= schema.singular %>.id), method: :delete, data: [confirm: "Are you sure?"]) %></li>
       <%% end %>


### PR DESCRIPTION
Fixes an issue where `@resource.id` does not exist on the index page

I was getting this error:
```
(KeyError) key :id not found in: %Paginator.Page{entries: [...],
  metadata: %Paginator.Page.Metadata{after: nil, before: nil, limit: 50, total_count: nil,
  total_count_cap_exceeded: nil}}
````

I believe this is to determine whether or not we are on a show/edit page rather than the index page.

My project is running: Elixir 1.9, Phoenix 1.4