### PR TITLE
Use table-layout: fixed to prevent table from overflowing

### DIFF
--- a/priv/templates/mandarin.install/layout.html.eex
+++ b/priv/templates/mandarin.install/layout.html.eex
@@ -25,6 +25,13 @@ scratch. This page gets rid of all links and provides the needed markup only.
   <%%# Google Font %>
   <link rel="stylesheet"
         href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+
+  <%%# Tables should be contained within their containers %>
+  <style>
+    .table {
+      table-layout: fixed
+    }
+  </style>
 </head>
 <%%#
 BODY TAG OPTIONS:


### PR DESCRIPTION
A field with a long chunk of text that can't break will currently cause the whole table on the `index` page to overflow off the screen's edge in Chrome.

Using `table-layout: fixed` will respect the `width: 100% and max-width: 100%` settings already specified on the `.table` class.