### PR TITLE
Add empty map as default params for list schema access method

### DIFF
--- a/priv/templates/mandarin.gen.context/schema_access.ex
+++ b/priv/templates/mandarin.gen.context/schema_access.ex
@@ -13,7 +13,7 @@
       [%<%= inspect schema.alias %>{}, ...]
 
   """
-  def list_<%= schema.plural %>(params) do<% [{default_sort_field, _type} | _attrs] = schema.attrs %>
+  def list_<%= schema.plural %>(params \\ %{}) do<% [{default_sort_field, _type} | _attrs] = schema.attrs %>
     Forage.paginate(params, <%= inspect schema.alias %>, Repo, sort: [:<%= default_sort_field %>, :id], preload: <%= inspect(preload) %>)
   end
 


### PR DESCRIPTION
Noticed in the tests that the `list` endpoint can be called as `list/0`.